### PR TITLE
Fixing issue #383 - /var/log/mariadb not created or owned

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -81,6 +81,16 @@
     - mysql_log | default(true)
     - mysql_log_error | default(false)
   tags: ['skip_ansible_galaxy']
+  
+- name: Create /var/log directory for logging if it does not exist
+  file:
+    path: "/var/log/mariadb/"
+    state: directory
+    recurse: yes
+    force: yes
+    owner: mysql
+    group: mysql
+    mode: 0664   
 
 - name: Ensure MySQL is started and enabled on boot.
   service: "name={{ mysql_daemon }} state=started enabled={{ mysql_enabled_on_startup }}"


### PR DESCRIPTION
Fixing similar issue to https://github.com/geerlingguy/ansible-role-mysql/pull/382/files with this addition:
https://github.com/geerlingguy/ansible-role-mysql/issues/383